### PR TITLE
Fixes to allow code to run

### DIFF
--- a/src/dftbp/dftbplus/initprogram.F90
+++ b/src/dftbp/dftbplus/initprogram.F90
@@ -2807,6 +2807,14 @@ contains
 
     call densityMatrixSource(this%densityMatrix, this%electronicSolver, input%ctrl%isDmOnGpu)
 
+  #:if WITH_SCALAPACK
+    call scalafx_getlocalshape(env%blacs%orbitalGrid, this%denseDesc%blacsOrbSqr, nLocalRows,&
+        & nLocalCols)
+  #:else
+    nLocalRows = this%denseDesc%fullSize
+    nLocalCols = this%denseDesc%fullSize
+  #:endif
+
     if (areNeighboursSymmetric) then
       allocate(this%symNeighbourList)
       allocate(this%symNeighbourList%neighbourList)
@@ -2849,14 +2857,6 @@ contains
         end if
 
       end if
-
-    #:if WITH_SCALAPACK
-      call scalafx_getlocalshape(env%blacs%orbitalGrid, this%denseDesc%blacsOrbSqr, nLocalRows,&
-          & nLocalCols)
-    #:else
-      nLocalRows = this%denseDesc%fullSize
-      nLocalCols = this%denseDesc%fullSize
-    #:endif
 
       if (this%isHybridXc) then
         ! allocation is necessary to hint "initializeCharges" what information to extract
@@ -5385,12 +5385,11 @@ contains
     !> Initialize storage for TI-DFTB TDMs
     !> TDK: nLocalCols is far too large in tests, so using nLocalRows twice
     !>      as a stopgap. Why is nLocalCols 1704689728 when nLocalRows is 22074?
-    write(*,*) 'TDMWRITE: nLocalRows, nLocalCols', nLocalRows, nLocalCols
-    if (this%deltaDftb%isTDM) then 
+    if (this%deltaDftb%isTDM) then
       allocate(this%transitionDipoleMoment(3))
-      allocate(this%tiMatG(nLocalRows,nLocalRows,this%nSpin))
-      allocate(this%tiMatE(nLocalRows,nLocalRows,this%nSpin))
-      allocate(this%tiMatPT(nLocalRows,nLocalRows))
+      allocate(this%tiMatG(nLocalRows,nLocalCols,this%nSpin))
+      allocate(this%tiMatE(nLocalRows,nLocalCols,this%nSpin))
+      allocate(this%tiMatPT(nLocalRows,nLocalCols))
       allocate(this%tiSigma(nLocalRows))
       allocate(this%gfilling(sqrHamSize, this%nKPoint, this%nSpin))
       allocate(this%mfilling(sqrHamSize, this%nKPoint, this%nSpin))

--- a/src/dftbp/dftbplus/main.F90
+++ b/src/dftbp/dftbplus/main.F90
@@ -3299,6 +3299,18 @@ contains
         @:PROPAGATE_ERROR(errStatus)
       end if
 
+      ! Store Hamiltonians for TDM calculation
+      write(*,*) 'TDMWRITE: Entering tiMat assignments'
+      if (deltaDftb%isTDM) then
+        if(deltaDftb%whichDeterminant(deltaDftb%iDeterminant) == determinants%ground) then
+          tiMatG(:,:,iKS) = HSqrReal
+        end if
+        if(deltaDftb%whichDeterminant(deltaDftb%iDeterminant) == determinants%mixed) then
+          tiMatE(:,:,iKS) = HSqrReal
+        end if
+      end if
+      write(*,*) 'TDMWRITE: Exiting tiMat assignments'
+
       call diagDenseMtxBlacs(electronicSolver, 1, 'V', denseDesc%blacsOrbSqr, HSqrReal, SSqrReal,&
           & eigen(:,iSpin), eigvecsReal(:,:,iKS), errStatus)
       @:PROPAGATE_ERROR(errStatus)
@@ -3325,33 +3337,31 @@ contains
         @:PROPAGATE_ERROR(errStatus)
       end if
 
-      ! Warning: SSqrReal gets overwritten here
+      ! Store Hamiltonians for TDM calculation
+      write(*,*) 'TDMWRITE: Entering tiMat assignments'
+      if (deltaDftb%isTDM) then
+        if(deltaDftb%whichDeterminant(deltaDftb%iDeterminant) == determinants%ground) then
+          tiMatG(:,:,iKS) = HSqrReal
+        end if
+        if(deltaDftb%whichDeterminant(deltaDftb%iDeterminant) == determinants%mixed) then
+          tiMatE(:,:,iKS) = HSqrReal
+        end if
+      end if
+      write(*,*) 'TDMWRITE: Exiting tiMat assignments'
+
+      ! Warning: SSqrReal and HSqrReal gets overwritten here
       call diagDenseMtx(env, electronicSolver, 'V', HSqrReal, SSqrReal, eigen(:, iSpin),&
           & errStatus)
       @:PROPAGATE_ERROR(errStatus)
       eigvecsReal(:,:,iKS) = HSqrReal
     #:endif
+
     end do
 
   #:if WITH_SCALAPACK
     ! Distribute all eigenvalues to all nodes via global summation
     call mpifx_allreduceip(env%mpi%interGroupComm, eigen, MPI_SUM)
   #:endif
-
- 
-    ! Store Hamiltonians for TDM calculation
-    write(*,*) 'TDMWRITE: Entering tiMat assignments'
-    if (deltaDftb%isTDM) then
-      if(deltaDftb%whichDeterminant(deltaDftb%iDeterminant) == determinants%ground) then
-        tiMatG(:,:,iKS) = 0.0_dp
-        tiMatG(:,:,iKS) = HSqrReal
-      end if
-      if(deltaDftb%whichDeterminant(deltaDftb%iDeterminant) == determinants%mixed) then
-        tiMatE(:,:,iKS) = 0.0_dp
-        tiMatE(:,:,iKS) = HSqrReal
-      end if
-    end if
-    write(*,*) 'TDMWRITE: Exiting tiMat assignments'
 
   end subroutine buildAndDiagDenseRealHam
 


### PR DESCRIPTION
Summary:
* Use of unitialised sizing variables fixed (nLocal* were only set for the hybrid functional code path in initprogram.F90, and na was never set in determinants.F90)
* Mulliken return sizing incompatible with variable being used, so introduce work array to match these together
* tiTraCharges was zeroing all spin channels when it should only zero the current one in determinants
* Fix for hamiltonian being stored after overwrite with eigenvectors