### PR TITLE
Trap for MPI compiled code

### DIFF
--- a/src/dftbp/dftbplus/initprogram.F90
+++ b/src/dftbp/dftbplus/initprogram.F90
@@ -2003,7 +2003,8 @@ contains
 
     ! DFTB related variables if multiple determinants are used
     call TDftbDeterminants_init(this%deltaDftb, input%ctrl%isNonAufbau, input%ctrl%isSpinPurify,&
-        & input%ctrl%isGroundGuess, input%ctrl%isTDM, this%nEl, this%dftbEnergy)
+        & input%ctrl%isGroundGuess, input%ctrl%isTDM, this%nEl, this%dftbEnergy, errStatus)
+    if (errStatus%hasError()) call error(errStatus%message)
 
     if (this%tForces) then
       this%tCasidaForces = input%ctrl%tCasidaForces

--- a/src/dftbp/dftbplus/main.F90
+++ b/src/dftbp/dftbplus/main.F90
@@ -23,7 +23,7 @@ module dftbp_dftbplus_main
   use dftbp_dftb_boundarycond, only : TBoundaryConditions
   use dftbp_dftb_densitymatrix, only : TDensityMatrix, transformDualSpaceToBvKRealSpace
   use dftbp_dftb_determinants, only : TDftbDeterminants, TDftbDeterminants_init, determinants,&
-      & tiTDM, tiTraDip
+      & tiTraDip
   use dftbp_dftb_dftbplusu, only : TDftbU
   use dftbp_dftb_dispersions, only : TDispersionIface
   use dftbp_dftb_energytypes, only : TEnergies
@@ -124,7 +124,7 @@ module dftbp_dftbplus_main
   use dftbp_dftb_sparse2dense, only : packRhoRealBlacs, packRhoCplxBlacs, packRhoPauliBlacs,&
       & packRhoHelicalRealBlacs, packRhoHelicalCplxBlacs, packERhoPauliBlacs, unpackHSRealBlacs,&
       & unpackHSCplxBlacs, unpackHPauliBlacs, unpackSPauliBlacs, unpackHSHelicalRealBlacs,&
-      & unpackHSHelicalCplxBlacs, tiTDM, tiTraDip
+      & unpackHSHelicalCplxBlacs
   use dftbp_dftbplus_eigenvects, only : diagDenseMtxBlacs
   use dftbp_extlibs_mpifx, only : MPI_SUM, MPI_MAX, mpifx_allreduceip, mpifx_bcast
   use dftbp_extlibs_scalapackfx, only : pblasfx_phemm, pblasfx_psymm, pblasfx_ptran,&
@@ -1582,7 +1582,8 @@ contains
               & this%coord0, this%iAtInCentralRegion, this%gfilling, this%mfilling, env)
       !> Write out the TDM, because TDM not avialable in time for writeDetailedOut7 dipole writeout
       write(stdOut,*)
-      write(stdOut,'(A, 3F14.8, A)') 'TI-DFTB Transition Dipole Moment:', this%transitionDipoleMoment, ' a.u.'
+      write(stdOut,'(A, 3F14.8, A)') 'TI-DFTB Transition Dipole Moment:',&
+          & this%transitionDipoleMoment, ' a.u.'
     end if
 
     if (allocated(this%scc)) then
@@ -3145,8 +3146,8 @@ contains
     call env%globalTimer%stopTimer(globalTimers%diagonalization)
 
     call getFillingsAndBandEnergies(eigen, nEl, nSpin, tempElec, kWeight, tSpinSharedEf,&
-        & tFillKSep, tFixEf, iDistribFn, Ef, filling, energy%Eband, energy%TS, energy%E0, deltaDftb,&
-        & gfilling, mfilling)
+        & tFillKSep, tFixEf, iDistribFn, Ef, filling, energy%Eband, energy%TS, energy%E0,&
+        & deltaDftb, gfilling, mfilling)
 
     call env%globalTimer%startTimer(globalTimers%densityMatrix)
     if (nSpin /= 4) then

--- a/test/app/dftb+/deltadftb/TDM-CO/C-C.skf
+++ b/test/app/dftb+/deltadftb/TDM-CO/C-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-C.skf

--- a/test/app/dftb+/deltadftb/TDM-CO/C-O.skf
+++ b/test/app/dftb+/deltadftb/TDM-CO/C-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/C-O.skf

--- a/test/app/dftb+/deltadftb/TDM-CO/O-C.skf
+++ b/test/app/dftb+/deltadftb/TDM-CO/O-C.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-C.skf

--- a/test/app/dftb+/deltadftb/TDM-CO/O-O.skf
+++ b/test/app/dftb+/deltadftb/TDM-CO/O-O.skf
@@ -1,1 +1,0 @@
-../../../../../external/slakos/origin/mio-1-1/O-O.skf

--- a/test/app/dftb+/deltadftb/TDM-CO/dftb_in.hsd
+++ b/test/app/dftb+/deltadftb/TDM-CO/dftb_in.hsd
@@ -27,6 +27,7 @@ Hamiltonian = DFTB{
   }
 
   SlaterKosterFiles = {
+    Prefix = "slakos/origin/mio-1-1/"
     C-C = "C-C.skf"
     C-O = "C-O.skf"
     O-C = "O-C.skf"


### PR DESCRIPTION
Remove language depreciated forall, fix some indentation and rename a couple of variables as per style guide. Also switch initialisation to current error return mechanism (needed eventualy for library use of DFTB+).

Also switch to more recent mechanism for finding SK files, removing need for symlinked files in the new test.